### PR TITLE
fix: dependabot release when non development changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,10 @@ updates:
     time: "09:00"
     timezone: "Europe/Oslo"
     day: "monday"
+  commit-message:
+    prefix: "fix"  # Use 'fix' for GitHub Actions updates so we get new releases
+    prefix-development: "chore" # Use 'chore' for development dependency updates
+    include: "scope"
   open-pull-requests-limit: 2
 - package-ecosystem: "npm"
   directory: "/fixture/functions"
@@ -35,3 +39,7 @@ updates:
     timezone: "Europe/Oslo"
     day: "monday"
   open-pull-requests-limit: 2
+  commit-message:
+    prefix: "chore" # Use 'chore' for testing and build tool updates
+    prefix-development: "chore" # Use 'chore' for development dependency updates
+    include: "scope"


### PR DESCRIPTION
When dependabot is bumping external actions like firebase.. make sure to release.