### PR TITLE
fix: Hardened deploy workflows, and lock firebase-tools used

### DIFF
--- a/.github/workflows/firebase-hosting-deploy.yml
+++ b/.github/workflows/firebase-hosting-deploy.yml
@@ -15,6 +15,10 @@ on:
         type: string
         description: "Entry point folder to deploy (Same folder as .firebase.json is located)"
         default: "."
+      tools_version:
+        type: string
+        description: "Optional Firebase-tools version to use when deploying"
+        default: "15.18.0"
       target:
         type: string
         description: "Optional Firebase Hosting target name to deploy"
@@ -76,10 +80,14 @@ jobs:
       - name: Firebase deploy
         id: firebase-deploy
         uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0.10.0
+        env:
+          NPM_CONFIG_IGNORE_SCRIPTS: true
+          NPM_CONFIG_MIN_RELEASE_AGE: 4
         with:
           firebaseServiceAccount: "${{ env.SERVICE_ACCOUNT_KEY }}"
           projectId: ${{ inputs.gcp_project_id }}
           entryPoint: ${{ inputs.entry_point }}
+          firebaseToolsVersion: ${{ inputs.tools_version }}
           target: ${{ inputs.target }}
           channelId: live
 

--- a/.github/workflows/firebase-hosting-preview.yml
+++ b/.github/workflows/firebase-hosting-preview.yml
@@ -17,6 +17,10 @@ on:
         type: string
         description: "Entry point folder to deploy"
         default: "."
+      tools_version:
+        type: string
+        description: "Optional Firebase-tools version to use when deploying"
+        default: "15.18.0"
       target:
         type: string
         description: "Optional Firebase Hosting target name to deploy"
@@ -100,10 +104,14 @@ jobs:
       - name: Firebase deploy preview
         id: firebase-deploy-preview
         uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0.10.0
+        env:
+          NPM_CONFIG_IGNORE_SCRIPTS: true
+          NPM_CONFIG_MIN_RELEASE_AGE: 4
         with:
           firebaseServiceAccount: "${{ env.SERVICE_ACCOUNT_KEY }}"
           projectId: ${{ inputs.gcp_project_id }}
           entryPoint: ${{ inputs.entry_point }}
+          firebaseToolsVersion: ${{ inputs.tools_version }}
           target: ${{ inputs.target }}
           channelId: ${{ env.CHANNEL_ID }}
           expires: ${{ inputs.preview_expire }}


### PR DESCRIPTION
This pull request locks the version of firebase-tools used for deployment, disables install scripts, and sets an age limit for transitive package installs. The end-goal being to harden the workflow against supply chain attacks originating from unpinned dependency installs (see https://github.com/FirebaseExtended/action-hosting-deploy/blob/main/src/deploy.ts#L90).

Closes: [SIK-1977]

[SIK-1977]: https://entur.atlassian.net/browse/SIK-1977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ