### PR TITLE
fix: Harden deploy/preview workflows against supply chain attacks

### DIFF
--- a/.github/workflows/firebase-hosting-deploy.yml
+++ b/.github/workflows/firebase-hosting-deploy.yml
@@ -15,6 +15,10 @@ on:
         type: string
         description: "Entry point folder to deploy (Same folder as .firebase.json is located)"
         default: "."
+      tools_version:
+        type: string
+        description: "Optional Firebase-tools version to use when deploying"
+        default: "15.18.0"
       target:
         type: string
         description: "Optional Firebase Hosting target name to deploy"
@@ -76,10 +80,14 @@ jobs:
       - name: Firebase deploy
         id: firebase-deploy
         uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0.10.0
+        env:
+          NPM_CONFIG_IGNORE_SCRIPTS: true
+          NPM_CONFIG_MIN_RELEASE_AGE: 4
         with:
           firebaseServiceAccount: "${{ env.SERVICE_ACCOUNT_KEY }}"
           projectId: ${{ inputs.gcp_project_id }}
           entryPoint: ${{ inputs.entry_point }}
+          firebaseToolsVersion: ${{ inputs.tools_version }}
           target: ${{ inputs.target }}
           channelId: live
 

--- a/.github/workflows/firebase-hosting-preview.yml
+++ b/.github/workflows/firebase-hosting-preview.yml
@@ -17,6 +17,10 @@ on:
         type: string
         description: "Entry point folder to deploy"
         default: "."
+      tools_version:
+        type: string
+        description: "Optional Firebase-tools version to use when deploying"
+        default: "15.18.0"
       target:
         type: string
         description: "Optional Firebase Hosting target name to deploy"
@@ -100,10 +104,14 @@ jobs:
       - name: Firebase deploy preview
         id: firebase-deploy-preview
         uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0.10.0
+        env:
+          NPM_CONFIG_IGNORE_SCRIPTS: true
+          NPM_CONFIG_MIN_RELEASE_AGE: 4
         with:
           firebaseServiceAccount: "${{ env.SERVICE_ACCOUNT_KEY }}"
           projectId: ${{ inputs.gcp_project_id }}
           entryPoint: ${{ inputs.entry_point }}
+          firebaseToolsVersion: ${{ inputs.tools_version }}
           target: ${{ inputs.target }}
           channelId: ${{ env.CHANNEL_ID }}
           expires: ${{ inputs.preview_expire }}

--- a/README-firebase-hosting-deploy.md
+++ b/README-firebase-hosting-deploy.md
@@ -19,15 +19,16 @@ jobs:
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|                                           INPUT                                           |  TYPE  | REQUIRED |  DEFAULT  |                                 DESCRIPTION                                  |
-|-------------------------------------------------------------------------------------------|--------|----------|-----------|------------------------------------------------------------------------------|
-| <a name="input_build_artifact_name"></a>[build_artifact_name](#input_build_artifact_name) | string |  false   |           |                 Name of GitHub artifact to <br>add to build                  |
-| <a name="input_build_artifact_path"></a>[build_artifact_path](#input_build_artifact_path) | string |  false   | `"build"` |                             Path to the artifact                             |
-|             <a name="input_entry_point"></a>[entry_point](#input_entry_point)             | string |  false   |   `"."`   | Entry point folder to deploy <br>(Same folder as .firebase.json is located)  |
-|             <a name="input_environment"></a>[environment](#input_environment)             | string |   true   |           |                  Environment to deploy to (dev, tst, prd)                    |
-|        <a name="input_gcp_project_id"></a>[gcp_project_id](#input_gcp_project_id)         | string |   true   |           |                                GCP Project ID                                |
-|                    <a name="input_target"></a>[target](#input_target)                     | string |  false   |           |             Optional Firebase Hosting target name <br>to deploy              |
-|       <a name="input_timeout_minutes"></a>[timeout_minutes](#input_timeout_minutes)       | number |  false   |   `20`    |                              Timeout in minutes                              |
+|                                           INPUT                                           |  TYPE  | REQUIRED |   DEFAULT   |                                 DESCRIPTION                                  |
+|-------------------------------------------------------------------------------------------|--------|----------|-------------|------------------------------------------------------------------------------|
+| <a name="input_build_artifact_name"></a>[build_artifact_name](#input_build_artifact_name) | string |  false   |             |                 Name of GitHub artifact to <br>add to build                  |
+| <a name="input_build_artifact_path"></a>[build_artifact_path](#input_build_artifact_path) | string |  false   |  `"build"`  |                             Path to the artifact                             |
+|             <a name="input_entry_point"></a>[entry_point](#input_entry_point)             | string |  false   |    `"."`    | Entry point folder to deploy <br>(Same folder as .firebase.json is located)  |
+|             <a name="input_environment"></a>[environment](#input_environment)             | string |   true   |             |                  Environment to deploy to (dev, tst, prd)                    |
+|        <a name="input_gcp_project_id"></a>[gcp_project_id](#input_gcp_project_id)         | string |   true   |             |                                GCP Project ID                                |
+|                    <a name="input_target"></a>[target](#input_target)                     | string |  false   |             |             Optional Firebase Hosting target name <br>to deploy              |
+|       <a name="input_timeout_minutes"></a>[timeout_minutes](#input_timeout_minutes)       | number |  false   |    `20`     |                              Timeout in minutes                              |
+|          <a name="input_tools_version"></a>[tools_version](#input_tools_version)          | string |  false   | `"15.18.0"` |          Optional Firebase-tools version to use <br>when deploying           |
 
 <!-- AUTO-DOC-INPUT:END -->
 

--- a/README-firebase-hosting-preview.md
+++ b/README-firebase-hosting-preview.md
@@ -19,16 +19,17 @@ jobs:
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|                                           INPUT                                           |  TYPE  | REQUIRED |  DEFAULT  |                     DESCRIPTION                      |
-|-------------------------------------------------------------------------------------------|--------|----------|-----------|------------------------------------------------------|
-| <a name="input_build_artifact_name"></a>[build_artifact_name](#input_build_artifact_name) | string |  false   |           |     Name of GitHub artifact to <br>add to build      |
-| <a name="input_build_artifact_path"></a>[build_artifact_path](#input_build_artifact_path) | string |  false   | `"build"` |                 Path to the artifact                 |
-|             <a name="input_entry_point"></a>[entry_point](#input_entry_point)             | string |  false   |   `"."`   |             Entry point folder to deploy             |
-|             <a name="input_environment"></a>[environment](#input_environment)             | string |   true   |           |      Environment to deploy to (dev, tst, prd)        |
-|        <a name="input_gcp_project_id"></a>[gcp_project_id](#input_gcp_project_id)         | string |   true   |           |                    GCP Project ID                    |
-|        <a name="input_preview_expire"></a>[preview_expire](#input_preview_expire)         | string |  false   |  `"7d"`   |                 Preview expire time                  |
-|                    <a name="input_target"></a>[target](#input_target)                     | string |  false   |           | Optional Firebase Hosting target name <br>to deploy  |
-|       <a name="input_timeout_minutes"></a>[timeout_minutes](#input_timeout_minutes)       | number |  false   |   `20`    |                  Timeout in minutes                  |
+|                                           INPUT                                           |  TYPE  | REQUIRED |   DEFAULT   |                        DESCRIPTION                         |
+|-------------------------------------------------------------------------------------------|--------|----------|-------------|------------------------------------------------------------|
+| <a name="input_build_artifact_name"></a>[build_artifact_name](#input_build_artifact_name) | string |  false   |             |        Name of GitHub artifact to <br>add to build         |
+| <a name="input_build_artifact_path"></a>[build_artifact_path](#input_build_artifact_path) | string |  false   |  `"build"`  |                    Path to the artifact                    |
+|             <a name="input_entry_point"></a>[entry_point](#input_entry_point)             | string |  false   |    `"."`    |                Entry point folder to deploy                |
+|             <a name="input_environment"></a>[environment](#input_environment)             | string |   true   |             |         Environment to deploy to (dev, tst, prd)           |
+|        <a name="input_gcp_project_id"></a>[gcp_project_id](#input_gcp_project_id)         | string |   true   |             |                       GCP Project ID                       |
+|        <a name="input_preview_expire"></a>[preview_expire](#input_preview_expire)         | string |  false   |   `"7d"`    |                    Preview expire time                     |
+|                    <a name="input_target"></a>[target](#input_target)                     | string |  false   |             |    Optional Firebase Hosting target name <br>to deploy     |
+|       <a name="input_timeout_minutes"></a>[timeout_minutes](#input_timeout_minutes)       | number |  false   |    `20`     |                     Timeout in minutes                     |
+|          <a name="input_tools_version"></a>[tools_version](#input_tools_version)          | string |  false   | `"15.18.0"` | Optional Firebase-tools version to use <br>when deploying  |
 
 <!-- AUTO-DOC-INPUT:END -->
 


### PR DESCRIPTION
This pull request locks the version of firebase-tools used for deployment, disables install scripts, and sets an age limit for transitive package installs. The end-goal being to harden the workflow against supply chain attacks originating from unpinned dependency installs (see https://github.com/FirebaseExtended/action-hosting-deploy/blob/main/src/deploy.ts#L90).

Closes: [SIK-1977]

[SIK-1977]: https://entur.atlassian.net/browse/SIK-1977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ