### PR TITLE
fix: Update workflows to use a newer version of npm which supports ag…

### DIFF
--- a/.github/workflows/firebase-hosting-deploy.yml
+++ b/.github/workflows/firebase-hosting-deploy.yml
@@ -55,6 +55,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24 
+
       - name: Authenticate with GCP
         id: auth
         uses: "google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093" # v3.0.0

--- a/.github/workflows/firebase-hosting-preview.yml
+++ b/.github/workflows/firebase-hosting-preview.yml
@@ -63,6 +63,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24 
+
       - name: Authenticate with GCP
         id: auth
         uses: "google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093" # v3.0.0


### PR DESCRIPTION
This PR is a follow-up to https://github.com/entur/gha-firebase/pull/132, to ensure that the npm version used for deployments in the firebase-deploy step, is of a newer version that actually supports age gates. Currently the standard version shipped in runner images is based around node 20 (see https://github.com/actions/runner-images/issues/14029)

Relates to [SIK-1977]

[SIK-1977]: https://entur.atlassian.net/browse/SIK-1977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ